### PR TITLE
add instances for NFData (RL a) and NFData (RLEof f a)

### DIFF
--- a/Text/Regex/Anagram/Types.hs
+++ b/Text/Regex/Anagram/Types.hs
@@ -136,9 +136,13 @@ instance Functor f => FoldCase (PatCharsOf f) where
     , patStar = foldCase patStar
     }
 
+instance NFData a => NFData (RL a) where
+  rnf = rnf1
 instance NFData1 RL where
   liftRnf f (RL a _) = f a
 
+instance (NFData1 f, NFData a) => NFData (RLEof f a) where
+  rnf = rnf1
 instance NFData1 f => NFData1 (RLEof f) where
   liftRnf f (RLE l) = liftRnf (liftRnf f) l
 


### PR DESCRIPTION
deepseq >= 1.5 requires these superclasses to exist even if anagrep doesn't need them. I'm not a 100% positive implementing rnf like this is permissible since this equivalency (at least in my mind) is not stated explicitly by deepseq e.g. as a law?!

See also https://github.com/haskell/deepseq/issues/88.